### PR TITLE
feat: Added extensions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ import localResolve from 'rollup-plugin-local-resolve';
 // This will resolve `./files` to `./files/index.js` if the file exists
 rollup({
   entry: './files',
-  plugins: [localResolve()],
+  plugins: [localResolve({
+    extensions: ['.jsx', '.js'] // default ['.js']
+  })],
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-local-resolve",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "Resolves index.js files with Rollup",
   "main": "dist/rollup-plugin-local-resolve.js",
   "jsnext:main": "dist/rollup-plugin-local-resolve.es2015.js",

--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,8 @@ export default function localResolver(options = { extensions: ['.js'] }) {
 
       let resolved = null;
 
-      // find will stop at the first occurrency
+      // find will stop at the first occurrence
       options.extensions.find(extension => {
-
         const dirIndexFile = path.join(directory + importee, `index${extension}`);
 
         // TODO: This should be asynchronous
@@ -35,6 +34,8 @@ export default function localResolver(options = { extensions: ['.js'] }) {
           resolved = dirIndexFile;
           return true;
         }
+
+        return false;
       });
 
       return resolved;


### PR DESCRIPTION
This adds an `extensions` option like in rollup-plugin-node-resolve to allow to look for several extensions at the same time. The first found will be used.

fixes #1